### PR TITLE
fix support for --container-tool-extra-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ $ python3 -m fab build --fabfile Fabfile.example
 ```
 
 The above will trigger container image builds in sequence for each of the modules and the final one at the end.
+
+
+Debugging messages can be enabled in fab with the `--log-level debug` switch, and in the underlying podman call with the `--container-tool-extra-args` switch:
+
+```
+$ python3 -m fab --container-tool-extra-args="--log-level debug" --log-level debug  build --fabfile Fabfile.example
+```

--- a/fab/cli.py
+++ b/fab/cli.py
@@ -79,7 +79,7 @@ class FabCli():
                             default='/usr/bin/podman')
         parser.add_argument('--container-tool-extra-args',
                             help='container tool extra arguments',
-                            default=[])
+                            default="")
 
         subparsers = parser.add_subparsers(dest='command')
         subparsers.required = False

--- a/fab/fab.py
+++ b/fab/fab.py
@@ -9,7 +9,7 @@ class Fab:
     Fabfile definition
     """
 
-    def __init__(self, source, container_tool='/usr/bin/podman', tool_args=[]):
+    def __init__(self, source, container_tool='/usr/bin/podman', tool_args=""):
         self.source = source
         self.name = source
         self.container_tool = container_tool
@@ -97,8 +97,7 @@ class Fab:
             tag = '{}-stage-{}'.format(
                 self.name,
                 module.name)
-            podman_args = []
-            podman_args.append(self.tool_args)
+            podman_args = self.tool_args.split()
             podman_args.append('build')
             podman_args.append('--from')
             podman_args.append(previous_container_image)
@@ -114,8 +113,7 @@ class Fab:
             logging.info('Start build of {} stage'.format(tag))
             self._run(self.container_tool, podman_args, module.working_dir)
             previous_container_image = tag
-        podman_args = []
-        podman_args.append(self.tool_args)
+        podman_args = self.tool_args.split()
         podman_args.append('tag')
         podman_args.append(previous_container_image)
         podman_args.append(self.name)


### PR DESCRIPTION
previously if `--container-tool-extra-args` was not passed fab would crash with "TypeError: expected str not list"  errors caused by container_tools_extra_args defaulting to an array. 
Also there was no way to pass multiple extra-args or multipart args (e.g. "--loglevel debug").

This PR defaults the argument for `--container-tool-extra-args` to a string which can include whitespace. This is then split() up and appended to the podman call, so instead of everything ending up in one item in the podman_args list, it now ends up in multiple items.

I've also added an example to the README  to show how to use it.