### PR TITLE
Add mount opt module

### DIFF
--- a/modules/mount/opt.Containerfile
+++ b/modules/mount/opt.Containerfile
@@ -1,0 +1,22 @@
+ARG BASEIMAGE="quay.io/centos-bootc/centos-bootc:stream9"
+
+FROM ${BASEIMAGE}
+
+RUN cat <<EOF > /etc/systemd/system/opt.mount
+[Unit]
+Description=OverlayFS for /opt
+DefaultDependencies=no
+After=local-fs.target
+Before=multi-user.target
+
+[Mount]
+What=overlay
+Where=/opt
+Type=overlay
+Options=lowerdir=/opt,upperdir=/var/opt/overlay-upper,workdir=/var/opt/overlay-work
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+RUN systemctl enable opt.mount

--- a/modules/mount/opt.yaml
+++ b/modules/mount/opt.yaml
@@ -1,0 +1,6 @@
+---
+metadata:
+  name: opt
+  description: |
+    make /opt writable via an overlay filesystem
+containerfile: opt.Containerfile


### PR DESCRIPTION
This PR adds a module to setup an overlay filesystem on top of `/opt` to make it writable. This addresses a popular issue in OSTree-based OSes for RPMs and/or agents that still use `/opt` for their configuration and/or runtime files.